### PR TITLE
Remove unnecessary .gitignore from images folder

### DIFF
--- a/public_html/images/.gitignore
+++ b/public_html/images/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
This .gitignore is not needed, since someone that wants to build the HTML, needs the images too.